### PR TITLE
updated data sets for stretch goal

### DIFF
--- a/utils/data/member_data.json
+++ b/utils/data/member_data.json
@@ -4,6 +4,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8479994.png",
     "name":"Jaret Anderson-Dolan",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHintHTfvEgVuRj":{
@@ -11,6 +12,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8478463.png",
     "name":"Anthony Beauvillier",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHintHTfvEgVuRk":{
@@ -18,6 +20,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8482146.png",
     "name":"Luke Evangelista",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHjqRH6xAEzkH2C":{
@@ -25,6 +28,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8476887.png",
     "name":"Filip Forsberg",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHk_Pj3iXPzocEF":{
@@ -32,6 +36,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8479996.png",
     "name":"Cody Glass",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHlopNSZEfjJDoZ":{
@@ -39,6 +44,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8476873.png",
     "name":"Mark Jankowski",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHmwC99aHLKYory":{
@@ -46,6 +52,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8477446.png",
     "name":"Michael McCarron",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHn98uFhVWsBcj1":{
@@ -53,6 +60,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8478438.png",
     "name":"Tommy Novak",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHo8uy20E7vuEer":{
@@ -60,6 +68,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8474679.png",
     "name":"Gustav Nyquist",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHpLws4380LiOfZ":{
@@ -67,6 +76,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8475158.png",
     "name":"Ryan O'Reilly",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHq6n5-YLjwzOo1":{
@@ -74,6 +84,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8480748.png",
     "name":"Kiefer Sherwood",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHr0ZWftYll7UqY":{
@@ -81,6 +92,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8476925.png",
     "name":"Colton Sissons",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHsE5ydJ3iEcXe5":{
@@ -88,6 +100,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8482062.png",
     "name":"Cole Smith",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHsE5ydJ3iEcXe6":{
@@ -95,6 +108,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8475722.png",
     "name":"Jason Zucker",
     "role":"Forward",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHt2mkA9cVy4yrb":{
@@ -102,6 +116,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8475197.png",
     "name":"Tyson Barrie",
     "role":"Defenseman",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHt2mkA9cVy4yrc":{
@@ -109,6 +124,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8478851.png",
     "name":"Alexandre Carrier",
     "role":"Defenseman",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHuC49BWgrjJ1c2":{
@@ -116,6 +132,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8479371.png",
     "name":"Dante Fabbro",
     "role":"Defenseman",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHuC49BWgrjJ1c3":{
@@ -123,6 +140,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8474600.png",
     "name":"Roman Josi",
     "role":"Defenseman",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHuC49BWgrjJ1c4":{
@@ -130,6 +148,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8478468.png",
     "name":"Jeremy Lauzon",
     "role":"Defenseman",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHvPXKP-HNPfBbv":{
@@ -137,6 +156,7 @@
     "image":"https://assets.nhle.com/mugs/nhl/20232024/NSH/8474151.png",
     "name":"Ryan McDonagh",
     "role":"Defenseman",
+    "team_id": "-NvNkVHgo65i6LK789b-",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   }
 }

--- a/utils/data/team_data.json
+++ b/utils/data/team_data.json
@@ -1,0 +1,18 @@
+{
+  "-NvNkVHgo65i6LK789b-":{
+    "firebaseKey":"-NvNkVHgo65i6LK789b-",
+    "logo":"https://upload.wikimedia.org/wikipedia/en/thumb/9/9c/Nashville_Predators_Logo_%282011%29.svg/1200px-Nashville_Predators_Logo_%282011%29.svg.png",
+    "team_name":"Predators",
+    "city": "Nashville",
+    "state": "Tennessee",
+    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+  },
+  "-NvNkVHintHTfvEgVvTi":{
+    "firebaseKey":"-NvNkVHintHTfvEgVvTi",
+    "logo":"https://upload.wikimedia.org/wikipedia/en/thumb/4/45/Colorado_Avalanche_logo.svg/1200px-Colorado_Avalanche_logo.svg.png",
+    "team_name":"Avalanche",
+    "city": "Denver",
+    "state": "Colorado",
+    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+  }
+}


### PR DESCRIPTION
## Description
Updated data sets to move forward with stretch goal two.
Created Team data set with two teams including: firebaseKey, logo, team_name, city, state, uid
## Related Issue
#26 

## Motivation and Context
allows future tickets to be completed regarding CRUD for teams

## How Can This Be Tested?
review datasets for accuracy


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
