### PR TITLE
added Team option to Member Form

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -24,7 +24,7 @@ export default function NavBar() {
               <Nav.Link>Teams</Nav.Link>
             </Link>
             <Link passHref href="/members">
-              <Nav.Link>Teams</Nav.Link>
+              <Nav.Link>Members</Nav.Link>
             </Link>
             <Link passHref href="/team/new">
               <Nav.Link>New Team</Nav.Link>

--- a/components/forms/MemberForm.js
+++ b/components/forms/MemberForm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Button, FloatingLabel, Form } from 'react-bootstrap';
 import { useAuth } from '../../utils/context/authContext';
 import { createMember, updateMember } from '../../api/memberData';
+import { getTeams } from '../../api/teamData';
 
 const initialState = {
   name: '',
@@ -14,10 +15,13 @@ const initialState = {
 
 export default function MemberForm({ memberObj }) {
   const [formInput, setFormInput] = useState(initialState);
+  const [teams, setTeams] = useState([]);
   const router = useRouter();
   const { user } = useAuth();
 
   useEffect(() => {
+    getTeams(user.uid).then(setTeams);
+
     if (memberObj.firebaseKey) {
       setFormInput(memberObj);
     }
@@ -34,13 +38,13 @@ export default function MemberForm({ memberObj }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (memberObj.firebaseKey) {
-      updateMember(formInput).then(() => router.push('/'));
+      updateMember(formInput).then(() => router.push('/members'));
     } else {
       const payload = { ...formInput, uid: user.uid };
       createMember(payload).then(({ name }) => {
         const patchPayload = { firebaseKey: name };
         updateMember(patchPayload).then(() => {
-          router.push('/');
+          router.push('/members');
         });
       });
     }
@@ -91,6 +95,27 @@ export default function MemberForm({ memberObj }) {
             <option key="Goalie" value="Goalie">Goalie</option>
           </Form.Select>
         </FloatingLabel>
+        <FloatingLabel controlId="floatingSelect2" label="Team">
+          <Form.Select
+            aria-label="Team Selector"
+            name="team_id"
+            onChange={handleChange}
+            value={memberObj.team_id}
+            required
+          >
+            <option value="">Select Team</option>
+            {
+              teams.map((team) => (
+                <option
+                  key={team.firebaseKey}
+                  value={team.firebaseKey}
+                >
+                  {team.team_name}
+                </option>
+              ))
+            }
+          </Form.Select>
+        </FloatingLabel>
       </>
       <Button type="submit">{memberObj.firebaseKey ? 'Update' : 'Create'} Member</Button>
     </Form>
@@ -102,6 +127,7 @@ MemberForm.propTypes = {
     name: PropTypes.string,
     image: PropTypes.string,
     role: PropTypes.string,
+    team_id: PropTypes.string,
     firebaseKey: PropTypes.string,
   }),
 };

--- a/pages/members.js
+++ b/pages/members.js
@@ -1,9 +1,33 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
+import { useAuth } from '../utils/context/authContext';
 
-export default function members() {
+import { getMembers } from '../api/memberData';
+import MemberCard from '../components/MemberCard';
+
+function ViewAllMembers() {
+  const [members, setMembers] = useState([]);
+
+  const { user } = useAuth();
+
+  const getAllMembers = () => {
+    getMembers(user.uid).then(setMembers);
+  };
+
+  useEffect(() => {
+    getAllMembers();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <div>
-      <h1>Members</h1>
-    </div>
+    <>
+      <h1>All Members</h1>
+      <div className="d-flex flex-wrap">
+        {members.map((member) => (
+          <MemberCard memberObj={member} key={member.firebaseKey} onUpdate={getAllMembers} />
+        ))}
+      </div>
+    </>
   );
 }
+
+export default ViewAllMembers;


### PR DESCRIPTION
## Description
On the Create New Team Member and Edit Team Member Form, an option to select/change the team the player is on has been added.

## Related Issue
#28 

## Motivation and Context
This allows users to select Teams that the members are on when creating a new member or when editing an existing member.

## How Can This Be Tested?
Login ->
click Add New Team Member/Edit ->
complete form & submit ->
verify team member added to the page, verify team name added/edited in firebase

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
