### PR TITLE
added public toggle function and emoji

### DIFF
--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -3,8 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 import { deleteTeamsAndMembers } from '../api/mergedData';
+import { updateTeam } from '../api/teamData';
 
 export default function TeamCard({ teamObj, onUpdate }) {
+  const togglePublic = () => {
+    if (teamObj.public) {
+      updateTeam({ ...teamObj, public: false }).then(onUpdate);
+    } else {
+      updateTeam({ ...teamObj, public: true }).then(onUpdate);
+    }
+  };
+
   const deleteThisTeam = () => {
     if (window.confirm(`Are you sure you want to delete Team ${teamObj.team_name} and all of it's members?`)) {
       deleteTeamsAndMembers(teamObj.firebaseKey).then(() => onUpdate());
@@ -16,6 +25,7 @@ export default function TeamCard({ teamObj, onUpdate }) {
       <Card.Img className="card-image" variant="top" src={teamObj.logo} />
       <Card.Body>
         <Card.Title>{teamObj.team_name}</Card.Title>
+        <Button variant="light" className="m-2" onClick={togglePublic}>{teamObj.public ? '🌎' : '🔒'}</Button>
         <Card.Text>{teamObj.city}, {teamObj.state}</Card.Text>
         <Link href={`/team/${teamObj.firebaseKey}`} passHref>
           <Button variant="dark">View</Button>
@@ -36,6 +46,7 @@ TeamCard.propTypes = {
     firebaseKey: PropTypes.string,
     city: PropTypes.string,
     state: PropTypes.string,
+    public: PropTypes.bool,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description
Added toggle functionality and button on team card component for public/private toggling.

## Related Issue
#52 

## Motivation and Context
This change is required to move forward with stretch goal three and allow users to toggle/view private/public teams.

## How Can This Be Tested?
login ->
view teams ->
click private/public button ->
confirm team card is updated, confirm firebase updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
