### PR TITLE
added public toggle to team form

### DIFF
--- a/components/forms/TeamForm.js
+++ b/components/forms/TeamForm.js
@@ -107,6 +107,20 @@ export default function TeamForm({ teamObj }) {
               required
             />
           </FloatingLabel>
+          <Form.Check
+            className="text-black mb-3"
+            type="switch"
+            id="public"
+            name="public"
+            label="Public?"
+            checked={formInput.public}
+            onChange={(e) => {
+              setFormInput((prevState) => ({
+                ...prevState,
+                public: e.target.checked,
+              }));
+            }}
+          />
 
         </>
         <Button variant="dark" type="submit">{teamObj.firebaseKey ? 'Update' : 'Create'} Team</Button>


### PR DESCRIPTION
## Description
Added a public toggle to the new team form and the edit team form

## Related Issue
#53 

## Motivation and Context
This change allows users to toggle public/private when creating a team or when updating a team

## How Can This Be Tested?
login ->
edit team ->
confirm toggle functionality ->
submit edit -> 
confirm toggle worked
complete the same steps for creating a tea.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
