### PR TITLE
added creator details to public teams

### DIFF
--- a/components/forms/TeamForm.js
+++ b/components/forms/TeamForm.js
@@ -37,7 +37,9 @@ export default function TeamForm({ teamObj }) {
     if (teamObj.firebaseKey) {
       updateTeam(formInput).then(() => router.push('/teams'));
     } else {
-      const payload = { ...formInput, uid: user.uid };
+      const payload = {
+        ...formInput, uid: user.uid, creator: user.displayName, creatorEmail: user.email,
+      };
       createTeam(payload).then(({ name }) => {
         const patchPayload = { firebaseKey: name };
         updateTeam(patchPayload).then(() => {

--- a/pages/team/[firebaseKey].js
+++ b/pages/team/[firebaseKey].js
@@ -19,6 +19,9 @@ export default function ViewTeam() {
         <div className="ms-5 details">
           <h1 className="details-name">{teamDetails.team_name}</h1>
           <p>{teamDetails.city}, {teamDetails.state}</p>
+          {teamDetails.public
+            ? <><p>Created By: {teamDetails.creator}</p><p>Creator Email: {teamDetails.creatorEmail}</p></>
+            : ''}
         </div>
       </div>
       <div className="ms-5 details">

--- a/utils/data/team_data.json
+++ b/utils/data/team_data.json
@@ -6,6 +6,8 @@
     "city": "Nashville",
     "state": "Tennessee",
     "public": false,
+    "creator": "Felicia Mings",
+    "creatorEmail": "mingsfelicia@gmail.com",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHintHTfvEgVvTi":{
@@ -15,6 +17,8 @@
     "city": "Denver",
     "state": "Colorado",
     "public": true,
+    "creator": "Felicia Mings",
+    "creatorEmail": "mingsfelicia@gmail.com",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvnAniIY1HsJcWPx-3N":{
@@ -24,6 +28,8 @@
     "city": "Washington D.C.",
     "state": ".",
     "public": true,
+    "creator": "Felicia Mings",
+    "creatorEmail": "felicia.mings13@gmail.com",
     "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
   ,
@@ -34,6 +40,8 @@
     "city": "Detroit",
     "state": "Michigan",
     "public": false,
+    "creator": "Felicia Mings",
+    "creatorEmail": "felicia.mings13@gmail.com",
     "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
 }


### PR DESCRIPTION
## Description
Added the ability to view creator information on the team details page for public teams.

## Related Issue
#55 

## Motivation and Context
This allows users to view who created teams that are marked as public. 

## How Can This Be Tested?
login ->
create a public team ->
confirm creator details are accurate on the team details page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
