### PR TITLE
removed edit delete buttons for non-creators of public teams

### DIFF
--- a/components/MemberCard.js
+++ b/components/MemberCard.js
@@ -30,10 +30,16 @@ export default function MemberCard({ memberObj, onUpdate }) {
           <Card.Title>{memberObj.team_id === team.firebaseKey ? team.team_name : ''}</Card.Title>
         ))}
         <Card.Text>{memberObj.role}</Card.Text>
-        <Link href={`/member/edit/${memberObj.firebaseKey}`} passHref>
-          <Button className="button" variant="secondary">Edit</Button>
-        </Link>
-        <Button className="button" variant="danger" onClick={deleteThisMember}>Delete</Button>
+        {memberObj.uid === user.uid
+          ? (
+            <>
+              <Link href={`/member/edit/${memberObj.firebaseKey}`} passHref>
+                <Button className="button" variant="secondary">Edit</Button>
+              </Link>
+              <Button className="button" variant="danger" onClick={deleteThisMember}>Delete</Button>
+            </>
+          )
+          : ''}
       </Card.Body>
     </Card>
   );
@@ -46,6 +52,7 @@ MemberCard.propTypes = {
     image: PropTypes.string,
     team_id: PropTypes.string,
     firebaseKey: PropTypes.string,
+    uid: PropTypes.string,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
   teamObj: PropTypes.shape({

--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 import { deleteTeamsAndMembers } from '../api/mergedData';
 import { updateTeam } from '../api/teamData';
+import { useAuth } from '../utils/context/authContext';
 
 export default function TeamCard({ teamObj, onUpdate }) {
+  const { user } = useAuth();
+
   const togglePublic = () => {
     if (teamObj.public) {
       updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
@@ -30,10 +33,16 @@ export default function TeamCard({ teamObj, onUpdate }) {
         <Link href={`/team/${teamObj.firebaseKey}`} passHref>
           <Button variant="dark">View</Button>
         </Link>
-        <Link href={`/team/edit/${teamObj.firebaseKey}`} passHref>
-          <Button className="button" variant="secondary">Edit</Button>
-        </Link>
-        <Button className="button" variant="danger" onClick={deleteThisTeam}>Delete</Button>
+        {teamObj.uid === user.uid
+          ? (
+            <>
+              <Link href={`/team/edit/${teamObj.firebaseKey}`} passHref>
+                <Button className="button" variant="secondary">Edit</Button>
+              </Link>
+              <Button className="button" variant="danger" onClick={deleteThisTeam}>Delete</Button>
+            </>
+          )
+          : '' }
       </Card.Body>
     </Card>
   );
@@ -47,6 +56,7 @@ TeamCard.propTypes = {
     city: PropTypes.string,
     state: PropTypes.string,
     public: PropTypes.bool,
+    uid: PropTypes.string,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
 };

--- a/utils/data/member_data.json
+++ b/utils/data/member_data.json
@@ -197,7 +197,7 @@
     "name":"Nicolas Aube-Kubel",
     "role":"Forward",
     "team_id": "-NvnAniIY1HsJcWPx-3N",
-    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+    "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   },
   "-Nvnl2BLemasSgsYTgQ_":{
     "firebaseKey":"-Nvnl2BLemasSgsYTgQ_",
@@ -205,6 +205,6 @@
     "name":"Nic Dowd",
     "role":"Forward",
     "team_id": "-NvnAniIY1HsJcWPx-3N",
-    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+    "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
 }


### PR DESCRIPTION
## Description
Removed the edit/delete buttons on team and member public cards when not logged in as the creator of the respective cards.

## Related Issue
#61 

## Motivation and Context
This change removes the ability for users to edit/delete public teams or members that they did not create.

## How Can This Be Tested?
login ->
confirm you cannot edit/delete any teams or members that are public that you did not create

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
