### PR TITLE
Remove card public toggle

### DIFF
--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -3,19 +3,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 import { deleteTeamsAndMembers } from '../api/mergedData';
-import { updateTeam } from '../api/teamData';
 import { useAuth } from '../utils/context/authContext';
 
 export default function TeamCard({ teamObj, onUpdate }) {
   const { user } = useAuth();
 
-  const togglePublic = () => {
-    if (teamObj.public) {
-      updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
-    } else {
-      updateTeam({ ...teamObj, public: true }).then(() => onUpdate());
-    }
-  };
+  // const togglePublic = () => {
+  //   if (teamObj.public) {
+  //     updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
+  //   } else {
+  //     updateTeam({ ...teamObj, public: true }).then(() => onUpdate());
+  //   }
+  // };
 
   const deleteThisTeam = () => {
     if (window.confirm(`Are you sure you want to delete Team ${teamObj.team_name} and all of it's members?`)) {
@@ -28,7 +27,7 @@ export default function TeamCard({ teamObj, onUpdate }) {
       <Card.Img className="card-image" variant="top" src={teamObj.logo} />
       <Card.Body>
         <Card.Title>{teamObj.team_name}</Card.Title>
-        <Button variant="light" className="m-2" onClick={togglePublic}>{teamObj.public ? '🌎' : '🔒'}</Button>
+        <p>{teamObj.public ? '🌎' : '🔒'}</p>
         <Card.Text>{teamObj.city}, {teamObj.state}</Card.Text>
         <Link href={`/team/${teamObj.firebaseKey}`} passHref>
           <Button variant="dark">View</Button>


### PR DESCRIPTION
## Description
Removed the toggle button from the team card to eliminate the refresh bug.

## Related Issue
#62 

## Motivation and Context
There was an issue with refreshing the UI between cards showing in the correct public/private div. removing the toggle eliminates this issue.

## How Can This Be Tested?
login ->
confirm you can no longer toggle between public and private on the team card ->
confirm you can still toggle between public and private within the create or edit form

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
