### PR TITLE
Stretch goal three

### DIFF
--- a/api/teamData.js
+++ b/api/teamData.js
@@ -88,6 +88,24 @@ const getTeamsMembers = (firebaseKey) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
+const getPublicTeams = () => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/teams.json?orderBy="public"&equalTo=true`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data) {
+        resolve(Object.values(data));
+      } else {
+        resolve([]);
+      }
+    })
+    .catch(reject);
+});
+
 export {
-  getTeams, createTeam, getSingleTeam, deleteSingleTeam, updateTeam, getTeamsMembers,
+  getTeams, createTeam, getSingleTeam, deleteSingleTeam, updateTeam, getTeamsMembers, getPublicTeams,
 };

--- a/components/MemberCard.js
+++ b/components/MemberCard.js
@@ -30,10 +30,16 @@ export default function MemberCard({ memberObj, onUpdate }) {
           <Card.Title>{memberObj.team_id === team.firebaseKey ? team.team_name : ''}</Card.Title>
         ))}
         <Card.Text>{memberObj.role}</Card.Text>
-        <Link href={`/member/edit/${memberObj.firebaseKey}`} passHref>
-          <Button className="button" variant="secondary">Edit</Button>
-        </Link>
-        <Button className="button" variant="danger" onClick={deleteThisMember}>Delete</Button>
+        {memberObj.uid === user.uid
+          ? (
+            <>
+              <Link href={`/member/edit/${memberObj.firebaseKey}`} passHref>
+                <Button className="button" variant="secondary">Edit</Button>
+              </Link>
+              <Button className="button" variant="danger" onClick={deleteThisMember}>Delete</Button>
+            </>
+          )
+          : ''}
       </Card.Body>
     </Card>
   );
@@ -46,6 +52,7 @@ MemberCard.propTypes = {
     image: PropTypes.string,
     team_id: PropTypes.string,
     firebaseKey: PropTypes.string,
+    uid: PropTypes.string,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
   teamObj: PropTypes.shape({

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -10,7 +10,7 @@ export default function NavBar() {
   return (
     <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
       <Container>
-        <Link passHref href="/">
+        <Link passHref href="/teams">
           <Navbar.Brand>Go Sports!</Navbar.Brand>
         </Link>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />

--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -3,8 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 import { deleteTeamsAndMembers } from '../api/mergedData';
+import { updateTeam } from '../api/teamData';
 
 export default function TeamCard({ teamObj, onUpdate }) {
+  const togglePublic = () => {
+    if (teamObj.public) {
+      updateTeam({ ...teamObj, public: false }).then(onUpdate);
+    } else {
+      updateTeam({ ...teamObj, public: true }).then(onUpdate);
+    }
+  };
+
   const deleteThisTeam = () => {
     if (window.confirm(`Are you sure you want to delete Team ${teamObj.team_name} and all of it's members?`)) {
       deleteTeamsAndMembers(teamObj.firebaseKey).then(() => onUpdate());
@@ -16,6 +25,7 @@ export default function TeamCard({ teamObj, onUpdate }) {
       <Card.Img className="card-image" variant="top" src={teamObj.logo} />
       <Card.Body>
         <Card.Title>{teamObj.team_name}</Card.Title>
+        <Button variant="light" className="m-2" onClick={togglePublic}>{teamObj.public ? '🌎' : '🔒'}</Button>
         <Card.Text>{teamObj.city}, {teamObj.state}</Card.Text>
         <Link href={`/team/${teamObj.firebaseKey}`} passHref>
           <Button variant="dark">View</Button>
@@ -36,6 +46,7 @@ TeamCard.propTypes = {
     firebaseKey: PropTypes.string,
     city: PropTypes.string,
     state: PropTypes.string,
+    public: PropTypes.bool,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
 };

--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 import { deleteTeamsAndMembers } from '../api/mergedData';
 import { updateTeam } from '../api/teamData';
+import { useAuth } from '../utils/context/authContext';
 
 export default function TeamCard({ teamObj, onUpdate }) {
+  const { user } = useAuth();
+
   const togglePublic = () => {
     if (teamObj.public) {
       updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
@@ -30,10 +33,16 @@ export default function TeamCard({ teamObj, onUpdate }) {
         <Link href={`/team/${teamObj.firebaseKey}`} passHref>
           <Button variant="dark">View</Button>
         </Link>
-        <Link href={`/team/edit/${teamObj.firebaseKey}`} passHref>
-          <Button className="button" variant="secondary">Edit</Button>
-        </Link>
-        <Button className="button" variant="danger" onClick={deleteThisTeam}>Delete</Button>
+        {teamObj.uid === user.uid
+          ? (
+            <>
+              <Link href={`/team/edit/${teamObj.firebaseKey}`} passHref>
+                <Button className="button" variant="secondary">Edit</Button>
+              </Link>
+              <Button className="button" variant="danger" onClick={deleteThisTeam}>Delete</Button>
+            </>
+          )
+          : '' }
       </Card.Body>
     </Card>
   );
@@ -47,6 +56,7 @@ TeamCard.propTypes = {
     city: PropTypes.string,
     state: PropTypes.string,
     public: PropTypes.bool,
+    uid: PropTypes.string,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
 };

--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -3,19 +3,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 import { deleteTeamsAndMembers } from '../api/mergedData';
-import { updateTeam } from '../api/teamData';
 import { useAuth } from '../utils/context/authContext';
 
 export default function TeamCard({ teamObj, onUpdate }) {
   const { user } = useAuth();
 
-  const togglePublic = () => {
-    if (teamObj.public) {
-      updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
-    } else {
-      updateTeam({ ...teamObj, public: true }).then(() => onUpdate());
-    }
-  };
+  // const togglePublic = () => {
+  //   if (teamObj.public) {
+  //     updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
+  //   } else {
+  //     updateTeam({ ...teamObj, public: true }).then(() => onUpdate());
+  //   }
+  // };
 
   const deleteThisTeam = () => {
     if (window.confirm(`Are you sure you want to delete Team ${teamObj.team_name} and all of it's members?`)) {
@@ -28,7 +27,7 @@ export default function TeamCard({ teamObj, onUpdate }) {
       <Card.Img className="card-image" variant="top" src={teamObj.logo} />
       <Card.Body>
         <Card.Title>{teamObj.team_name}</Card.Title>
-        <Button variant="light" className="m-2" onClick={togglePublic}>{teamObj.public ? '🌎' : '🔒'}</Button>
+        <p>{teamObj.public ? '🌎' : '🔒'}</p>
         <Card.Text>{teamObj.city}, {teamObj.state}</Card.Text>
         <Link href={`/team/${teamObj.firebaseKey}`} passHref>
           <Button variant="dark">View</Button>

--- a/components/TeamCard.js
+++ b/components/TeamCard.js
@@ -8,9 +8,9 @@ import { updateTeam } from '../api/teamData';
 export default function TeamCard({ teamObj, onUpdate }) {
   const togglePublic = () => {
     if (teamObj.public) {
-      updateTeam({ ...teamObj, public: false }).then(onUpdate);
+      updateTeam({ ...teamObj, public: false }).then(() => onUpdate());
     } else {
-      updateTeam({ ...teamObj, public: true }).then(onUpdate);
+      updateTeam({ ...teamObj, public: true }).then(() => onUpdate());
     }
   };
 

--- a/components/forms/TeamForm.js
+++ b/components/forms/TeamForm.js
@@ -37,7 +37,9 @@ export default function TeamForm({ teamObj }) {
     if (teamObj.firebaseKey) {
       updateTeam(formInput).then(() => router.push('/teams'));
     } else {
-      const payload = { ...formInput, uid: user.uid };
+      const payload = {
+        ...formInput, uid: user.uid, creator: user.displayName, creatorEmail: user.email,
+      };
       createTeam(payload).then(({ name }) => {
         const patchPayload = { firebaseKey: name };
         updateTeam(patchPayload).then(() => {

--- a/components/forms/TeamForm.js
+++ b/components/forms/TeamForm.js
@@ -107,6 +107,20 @@ export default function TeamForm({ teamObj }) {
               required
             />
           </FloatingLabel>
+          <Form.Check
+            className="text-black mb-3"
+            type="switch"
+            id="public"
+            name="public"
+            label="Public?"
+            checked={formInput.public}
+            onChange={(e) => {
+              setFormInput((prevState) => ({
+                ...prevState,
+                public: e.target.checked,
+              }));
+            }}
+          />
 
         </>
         <Button variant="dark" type="submit">{teamObj.firebaseKey ? 'Update' : 'Create'} Team</Button>

--- a/pages/team/[firebaseKey].js
+++ b/pages/team/[firebaseKey].js
@@ -19,6 +19,9 @@ export default function ViewTeam() {
         <div className="ms-5 details">
           <h1 className="details-name">{teamDetails.team_name}</h1>
           <p>{teamDetails.city}, {teamDetails.state}</p>
+          {teamDetails.public
+            ? <><p>Created By: {teamDetails.creator}</p><p>Creator Email: {teamDetails.creatorEmail}</p></>
+            : ''}
         </div>
       </div>
       <div className="ms-5 details">

--- a/pages/teams.js
+++ b/pages/teams.js
@@ -1,28 +1,41 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../utils/context/authContext';
 import TeamCard from '../components/TeamCard';
-import { getTeams } from '../api/teamData';
+import { getPublicTeams, getTeams } from '../api/teamData';
 
 export default function Teams() {
-  const [teams, setTeams] = useState([]);
+  const [publicTeams, setPublicTeams] = useState([]);
+  const [privateTeams, setPrivateTeams] = useState([]);
 
   const { user } = useAuth();
 
-  const getAllTeams = () => {
-    getTeams(user.uid).then(setTeams);
+  const getAllPublicTeams = () => {
+    getPublicTeams().then(setPublicTeams);
+  };
+
+  const getAllPrivateTeams = () => {
+    getTeams(user.uid).then(setPrivateTeams);
   };
 
   useEffect(() => {
-    getAllTeams();
+    getAllPrivateTeams();
+    getAllPublicTeams();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <>
       <h1>All Teams</h1>
+      <h3>Public Teams</h3>
       <div className="d-flex flex-wrap">
-        {teams.map((team) => (
-          <TeamCard teamObj={team} key={team.firebaseKey} onUpdate={getAllTeams} />
+        {publicTeams.map((team) => (
+          <TeamCard teamObj={team} key={team.firebaseKey} onUpdate={getAllPublicTeams} />
+        ))}
+      </div>
+      <h3>My Teams</h3>
+      <div className="d-flex flex-wrap">
+        {privateTeams.map((team) => (
+          <TeamCard teamObj={team} key={team.firebaseKey} onUpdate={getAllPrivateTeams} />
         ))}
       </div>
     </>

--- a/utils/data/member_data.json
+++ b/utils/data/member_data.json
@@ -190,5 +190,21 @@
     "role":"Goalie",
     "team_id": "-NvNkVHintHTfvEgVvTi",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+  },
+  "-Nvnku7sFZ9dSR0agx1G":{
+    "firebaseKey":"-Nvnku7sFZ9dSR0agx1G",
+    "image":"https://assets.nhle.com/mugs/nhl/20232024/WSH/8477979.png",
+    "name":"Nicolas Aube-Kubel",
+    "role":"Forward",
+    "team_id": "-NvnAniIY1HsJcWPx-3N",
+    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+  },
+  "-Nvnl2BLemasSgsYTgQ_":{
+    "firebaseKey":"-Nvnl2BLemasSgsYTgQ_",
+    "image":"https://assets.nhle.com/mugs/nhl/20232024/WSH/8475343.png",
+    "name":"Nic Dowd",
+    "role":"Forward",
+    "team_id": "-NvnAniIY1HsJcWPx-3N",
+    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   }
 }

--- a/utils/data/member_data.json
+++ b/utils/data/member_data.json
@@ -197,7 +197,7 @@
     "name":"Nicolas Aube-Kubel",
     "role":"Forward",
     "team_id": "-NvnAniIY1HsJcWPx-3N",
-    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+    "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   },
   "-Nvnl2BLemasSgsYTgQ_":{
     "firebaseKey":"-Nvnl2BLemasSgsYTgQ_",
@@ -205,6 +205,6 @@
     "name":"Nic Dowd",
     "role":"Forward",
     "team_id": "-NvnAniIY1HsJcWPx-3N",
-    "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+    "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
 }

--- a/utils/data/team_data.json
+++ b/utils/data/team_data.json
@@ -16,5 +16,24 @@
     "state": "Colorado",
     "public": true,
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
+  },
+  "-NvnAniIY1HsJcWPx-3N":{
+    "firebaseKey":"-NvnAniIY1HsJcWPx-3N",
+    "logo":"https://upload.wikimedia.org/wikipedia/commons/thumb/2/2d/Washington_Capitals.svg/1200px-Washington_Capitals.svg.png",
+    "team_name":"Capitals",
+    "city": "Washington D.C.",
+    "state": ".",
+    "public": true,
+    "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
+  }
+  ,
+  "-NvnAniIY1HsJcWPx-2Y":{
+    "firebaseKey":"-NvnAniIY1HsJcWPx-2Y",
+    "logo":"https://upload.wikimedia.org/wikipedia/en/thumb/e/e0/Detroit_Red_Wings_logo.svg/1200px-Detroit_Red_Wings_logo.svg.png",
+    "team_name":"Red wings",
+    "city": "Detroit",
+    "state": "Michigan",
+    "public": false,
+    "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
 }

--- a/utils/data/team_data.json
+++ b/utils/data/team_data.json
@@ -6,6 +6,8 @@
     "city": "Nashville",
     "state": "Tennessee",
     "public": false,
+    "creator": "Felicia Mings",
+    "creatorEmail": "mingsfelicia@gmail.com",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHintHTfvEgVvTi":{
@@ -15,6 +17,8 @@
     "city": "Denver",
     "state": "Colorado",
     "public": true,
+    "creator": "Felicia Mings",
+    "creatorEmail": "mingsfelicia@gmail.com",
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvnAniIY1HsJcWPx-3N":{
@@ -24,6 +28,8 @@
     "city": "Washington D.C.",
     "state": ".",
     "public": true,
+    "creator": "Felicia Mings",
+    "creatorEmail": "felicia.mings13@gmail.com",
     "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
   ,
@@ -34,6 +40,8 @@
     "city": "Detroit",
     "state": "Michigan",
     "public": false,
+    "creator": "Felicia Mings",
+    "creatorEmail": "felicia.mings13@gmail.com",
     "uid":"cpdFyWgMtyZIVtoXKwVL9rbSEi42"
   }
 }

--- a/utils/data/team_data.json
+++ b/utils/data/team_data.json
@@ -5,6 +5,7 @@
     "team_name":"Predators",
     "city": "Nashville",
     "state": "Tennessee",
+    "public": false,
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   },
   "-NvNkVHintHTfvEgVvTi":{
@@ -13,6 +14,7 @@
     "team_name":"Avalanche",
     "city": "Denver",
     "state": "Colorado",
+    "public": true,
     "uid":"VwEbZZ6VVLQF8Ew2bG2vYBidIc22"
   }
 }


### PR DESCRIPTION
## Description
Completed all items for stretch goal three.

- Team cards can now be switched between public and private through the create and edit form
- when private, only the creator can see the team
- when public, non-creators can only view the team card, view the members of the team, and view the creator details
- an icon has been added to the team card to indicate whether public or private

## Motivation and Context
The provides additional functionality to the site to allow users more interaction and visibility to teams and members.

## How Can This Be Tested?
login -> navigate through out the site, viewing and testing various functionalities

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
